### PR TITLE
Cleanup

### DIFF
--- a/SaneCase.php
+++ b/SaneCase.php
@@ -43,7 +43,7 @@ class SaneCase implements BeforeDisplayNoArticleTextHook {
 
 		$found = false;
 		foreach ( $res as $row ) {
-			if ( mb_strtolower( $row->page_title ) == mb_strtolower( $title->getDBkey() ) ) {
+			if ( mb_strtolower( $row->page_title ) === mb_strtolower( $title->getDBkey() ) ) {
 				// case-insensitive match
 				$found = true;
 			} else if (

--- a/SaneCase.php
+++ b/SaneCase.php
@@ -21,6 +21,7 @@ class SaneCase implements BeforeDisplayNoArticleTextHook {
 
 		$originalLength = mb_strlen( $title->getDBkey() );
 		$dbr = $this->loadBalancer->getConnection( DB_REPLICA );
+		
 		if ( $config->get( 'SaneCaseAutofixSpecialCharBreak' ) ) {
 			// Get chances to find one page with a special character matching, there may be several results that don't match the criteria
 			// while not getting a large result set
@@ -31,6 +32,7 @@ class SaneCase implements BeforeDisplayNoArticleTextHook {
 			$limit = 1;
 			$titleCond = [ 'convert(page_title using utf8mb4)' => $title->getDBkey() ];
 		}
+
 		// Get a list of pages which prefix matches the title
 		$res = $dbr->newSelectQueryBuilder()
 			->select( [ 'page_title', 'page_id' ] )
@@ -63,4 +65,5 @@ class SaneCase implements BeforeDisplayNoArticleTextHook {
 			}
 		}
 	}
+
 }

--- a/extension.json
+++ b/extension.json
@@ -7,6 +7,7 @@
 	"description": "Automatically redirect case mistakes",
 	"url": "https://www.mediawiki.org/wiki/Extension:SaneCase",
 	"license-name": "MIT",
+	"type": "other",
 	"requires": {
 		"MediaWiki": ">= 1.40.0"
 	},

--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,7 @@
 	"license-name": "MIT",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.40.0"
+		"MediaWiki": ">= 1.41.0"
 	},
 	"AutoloadClasses": {
 		"SaneCase": "SaneCase.php"
@@ -17,10 +17,17 @@
 	"ConfigRegistry": {
 		"sanecase": "GlobalVarConfig::newInstance"
 	},
+	"HookHandlers": {
+		"SaneCaseHooks": {
+			"class": "SaneCase",
+			"services": [
+				"ConfigFactory",
+				"DBLoadBalancer"
+			]
+		}
+	},
 	"Hooks": {
-		"BeforeDisplayNoArticleText": [
-			"SaneCase::onBeforeDisplayNoArticleText"
-		]
+		"BeforeDisplayNoArticleText": "SaneCaseHooks"
 	},
 	"config": {
 		"SaneCaseAutofixSpecialCharBreak": {


### PR DESCRIPTION
* Specify extension type in extension.json
* Use dependency injection instead of static calls to MediaWikiServices
* Raise MW requirement to 1.41 and add an import to the namespaced ConfigFactory class since the class alias is deprecated (1.40 is EOL anyways; so is 1.41, so in theory the requirement could be raised to 1.43)
* Use strict comparison to compare strings
* Add empty lines to improve readability